### PR TITLE
Replace error in static pages documentation.

### DIFF
--- a/docs/customize/static_pages.md
+++ b/docs/customize/static_pages.md
@@ -4,7 +4,7 @@
 InvenioILS provides additional functionality of defining static pages, in order to present addtional information for the end user.
 Example use case of a static page is 'About' or 'Contact' page.
 
-InvenioILS allows adding the custom pages through admin panel: `/admin/pages`, where it is possible to create new pages by clicking on `Create button`.
+InvenioILS allows adding the custom pages through admin panel: `/admin/page`, where it is possible to create new pages by clicking on `Create button`.
 The pages will be available under the routing specified in the creation form.
 The functionality is provided by invenio-pages module. Addtionally it is possible to GET the page created by REST API under `/api/pages/<page_id>` where expected payload is similar to the one below:
 


### PR DESCRIPTION
The url dedicated to add static pages in the admin panel was wrong. It should be /admin/page instead of /admin/pages.